### PR TITLE
Add proper IG structure

### DIFF
--- a/input/fsh/profiles/FiSchedulingAppointment.fsh
+++ b/input/fsh/profiles/FiSchedulingAppointment.fsh
@@ -1,8 +1,7 @@
 Profile: FiSchedulingAppointment
 Parent: Appointment
-Id: FiSchedulingAppointment
-Description: "Base profile for appointment (**ajanvaraus**) in Finnish Scheduling environment. The contents is based on the scheduling appointment specification."
-* ^url = "http://hl7.fi/fhir/StructureDefinition/FiSchedulingAppointment"
+Id: fi-scheduling-appointment
+Description: "Base profile for appointment (*ajanvaraus*) in Finnish Scheduling environment. The contents is based on the scheduling appointment specification."
 * extension ^slicing.discriminator.type = #value
 * extension ^slicing.discriminator.path = "url"
 * extension ^slicing.rules = #open

--- a/input/fsh/profiles/FiSchedulingHealthcareService.fsh
+++ b/input/fsh/profiles/FiSchedulingHealthcareService.fsh
@@ -2,7 +2,6 @@ Profile: FiSchedulingHealthcareService
 Parent: HealthcareService
 Id: fi-scheduling-healthcare-service
 Description: "Finnish profile for healthcare service."
-* ^url = "http://hl7.fi/fhir/StructureDefinition/FiSchedulingHealthcareService"
 * category ..1
 * category ^requirements = "71.1 Palvelun luokka"
 * category.coding.system = "urn:oid:1.2.246.537.6.88.2008" (exactly)

--- a/input/fsh/profiles/FiSchedulingLocation.fsh
+++ b/input/fsh/profiles/FiSchedulingLocation.fsh
@@ -1,8 +1,7 @@
 Profile: FiSchedulingLocation
 Parent: Location
 Id: fi-scheduling-location
-Description: "Details for schedulable location"
-* ^url = "http://hl7.fi/fhir/StructureDefinition/FiSchedulingLocation"
+Description: "Details for schedulable location."
 * identifier 1..1
 * identifier ^requirements = "79 Palveluntoteuttaja tai XX Palveluntoteuttajan palvelupisteen tunniste"
 * identifier.value ^requirements = "79 Palveluntoteuttaja tai XX Palveluntoteuttajan palvelupisteen tunniste"

--- a/input/fsh/profiles/FiSchedulingPatient.fsh
+++ b/input/fsh/profiles/FiSchedulingPatient.fsh
@@ -2,7 +2,6 @@ Profile: FiSchedulingPatient
 Parent: Patient
 Id: fi-scheduling-patient
 Description: "Resource profile for patient to be used in Finnish social and healthcare setting. Supports one official and one temporary id. Supports home municipality extension."
-* ^url = "http://hl7.fi/fhir/StructureDefinition/FiSchedulingPatient"
 * extension ^slicing.discriminator.type = #value
 * extension ^slicing.discriminator.path = "url"
 * extension ^slicing.rules = #open

--- a/input/fsh/profiles/FiSchedulingPractitioner.fsh
+++ b/input/fsh/profiles/FiSchedulingPractitioner.fsh
@@ -1,8 +1,7 @@
 Profile: FiSchedulingPractitioner
 Parent: Practitioner
 Id: fi-scheduling-practitioner
-Description: "Practitioner details for Finnish Scheduling (including various Finnish social and healthcare professional id types)"
-* ^url = "http://hl7.fi/fhir/StructureDefinition/FiSchedulingPractitioner"
+Description: "Practitioner details for Finnish Scheduling (including various Finnish social and healthcare professional id types)."
 * identifier 1..1
 * identifier ^slicing.discriminator.type = #value
 * identifier ^slicing.discriminator.path = "system"

--- a/input/fsh/profiles/FiSchedulingPractitionerRole.fsh
+++ b/input/fsh/profiles/FiSchedulingPractitionerRole.fsh
@@ -2,7 +2,6 @@ Profile: FiSchedulingPractitionerRole
 Parent: PractitionerRole
 Id: fi-scheduling-practitioner-role
 Description: "Role information for the practitioner."
-* ^url = "http://hl7.fi/fhir/StructureDefinition/FiSchedulingPractitionerRole"
 * identifier ..0
 * active ..0
 * period ..0

--- a/input/fsh/profiles/FiSchedulingSchedule.fsh
+++ b/input/fsh/profiles/FiSchedulingSchedule.fsh
@@ -1,8 +1,7 @@
 Profile: FiSchedulingSchedule
 Parent: Schedule
 Id: fi-scheduling-schedule
-Description: "Finnish profile for Schedule"
-* ^url = "http://hl7.fi/fhir/StructureDefinition/FiSchedulingSchedule"
+Description: "Finnish profile for Schedule."
 * identifier 1..1
 * identifier.use 0..
 * identifier.period 0..

--- a/input/fsh/profiles/FiSchedulingSlot.fsh
+++ b/input/fsh/profiles/FiSchedulingSlot.fsh
@@ -1,8 +1,7 @@
 Profile: FiSchedulingSlot
 Parent: Slot
 Id: fi-scheduling-slot
-Description: "Finnish profile for Slot"
-* ^url = "http://hl7.fi/fhir/StructureDefinition/FiSchedulingSlot"
+Description: "Finnish profile for Slot."
 * identifier ..1
 * identifier.use 0..
 * identifier.period 0..

--- a/input/includes/example-list-generator.html
+++ b/input/includes/example-list-generator.html
@@ -1,0 +1,32 @@
+{% assign my_types = "" %}
+{%- for r_hash in site.data.artifacts -%}
+  {% assign r_type = r_hash[0] | split: '/' | first %}
+  {%- assign r = r_hash[1] -%}
+  {%- if r.example -%}
+    {% assign my_types =  my_types | append: ","s | append: r_type %}
+  {%- endif -%}
+{% endfor %}
+{% assign my_array = my_types | split: "," %}
+{% assign my_array = my_array | sort | uniq %}
+
+{% assign lhtype = "" %}
+{% for i in my_array offset:1 %}
+  {% assign dhtype = i | split: '-' | first %}
+  {%- if lhtype != dhtype %}
+    {% assign lhtype = dhtype %}
+
+### {{ lhtype }} ### {#{{ lhtype }}}
+
+  {% endif %}
+
+  {%- for r_hash in site.data.pages -%}
+    {% assign r_type = r_hash[0] | split: '/' | first %}
+    {%- assign r = r_hash[1] -%}
+    {% assign dtype = r_type | split: '-' | first %}
+    {%- if r_type == i %}
+
+* [{{ r.title }}]({{ r_type }})
+
+    {% endif %}
+  {%- endfor -%}
+{% endfor %}

--- a/input/includes/fragment-fi-scheduling-profiles.html
+++ b/input/includes/fragment-fi-scheduling-profiles.html
@@ -1,0 +1,42 @@
+<ul>
+  {%- assign profiles = "" -%}
+  {%- for r_hash in site.data.structuredefinitions -%}
+    {%- assign r_type = r_hash[0] | split: "/"" | first -%}
+    {%- assign r = r_hash[1] -%}
+    {%- if r.kind == "resource" -%}
+      {%- unless r.example -%}
+        {%- unless r.type == "Extension" -%}
+          {%- assign prefix = r_type | slice: 0, 14 -%}
+          {%- if prefix == "fi-scheduling-" -%}
+            {%- assign escaped_description = r.description | replace: "%", "%25" -%}
+            {%- assign escaped_description = escaped_description | replace: ",", "%20" -%}
+            {%- assign escaped_description = escaped_description | replace: ":", "%3A" -%}
+            {%- assign profiles = profiles | append: r.path | append: ":" | append: r.title | append: ":" | append: escaped_description -%}
+            {%- unless forloop.last -%}
+              {%- assign profiles = profiles | append: "," -%}
+            {%- endunless -%}
+          {%- endif -%}
+        {%- endunless -%}
+      {%- endunless -%}
+    {%- endif -%}
+  {%- endfor -%}
+  {%- assign profiles = profiles | split: "," -%}
+  {%- assign profiles = profiles | sort | uniq -%}
+
+  {%- for profile in profiles -%}
+    {%- assign properties = profile | split: ":" -%}
+    {%- assign pagepath = properties.first -%}
+    {%- assign pagetitle = properties[1] -%}
+    {%- assign description = properties.last -%}
+    {%- assign description = description | replace: "%3A", ":" -%}
+    {%- assign description = description | replace: "%20", "," -%}
+    {%- assign description = description | replace: "%25", "%" -%}
+    {%- assign description = description | replace: "(*", "(<i>" -%}
+    {%- assign description = description | replace: "*)", "</i>)" -%}
+  <li>
+    <a href="{{ pagepath }}">{{ pagetitle }}</a>
+    <p>{{ description }}</p>
+  </li>
+  {%- endfor -%}
+
+</ul>

--- a/input/pagecontent/downloads.md
+++ b/input/pagecontent/downloads.md
@@ -1,0 +1,40 @@
+Download automatically generated assets for offline use.
+
+### This Implementation Guide
+
+This full IG as a single package:
+* [full-ig.zip](full-ig.zip)
+
+The ImplementationGuide resource:
+* Javascript Object Notation (JSON) format: [ImplementationGuide-hl7.fhir.fi.scheduling.json](ImplementationGuide-hl7.fhir.fi.scheduling.json)
+* Terse RDF Triple Language (TTL) format: [ImplementationGuide-hl7.fhir.fi.scheduling.ttl](ImplementationGuide-hl7.fhir.fi.scheduling.ttl)
+* Extensible Markup Language (XML) format: [ImplementationGuide-hl7.fhir.fi.scheduling.xml](ImplementationGuide-hl7.fhir.fi.scheduling.xml)
+
+### NPM Package
+
+Profiles, valuesets, examples, and other assets used in this IG in npm format:
+* FHIR version R4 [package.tgz](package.tgz)
+* FHIR version R4B [package.r4b.tgz](package.r4b.tgz)
+
+### Resources
+
+Profiles, valuesets, and other definitions included in this IG in different file formats:
+* Comma separated values (CSV) format: [csvs.zip](csvs.zip)
+* Excel spreadsheet files: [excels.zip](excels.zip)
+* Schematron XML validation language: [schematrons.zip](schematrons.zip)
+
+OpenAPI (a.k.a. Swagger) Definition Files of all Profiles and Extensions:
+* Javascript Object Notation (JSON) format: [definitions.json.zip](definitions.json.zip)
+* Terse RDF Triple Language (TTL) format: [definitions.ttl.zip](definitions.ttl.zip)
+* Extensible Markup Language (XML) format: [definitions.xml.zip](definitions.xml.zip)
+
+### Examples
+
+All example files included in this IG in different file formats:
+* JSON [examples.json.zip](examples.json.zip)
+* TTL [examples.ttl.zip](examples.ttl.zip)
+* XML [examples.xml.zip](examples.xml.zip)
+
+### FHIR Tools
+For generic FHIR tools, frameworks, and supported programming languages, see
+[https://hl7.org/fhir/downloads.html](https://hl7.org/fhir/downloads.html)

--- a/input/pagecontent/examples.md
+++ b/input/pagecontent/examples.md
@@ -1,0 +1,13 @@
+This list includes the examples included in this implementation guide.
+
+These example instances show what data produced and consumed by systems conforming with this
+implementation guide might look like. Every effort has been made to ensure that the examples are
+correct and useful, but they are not a normative part of the specification nor are they fully
+representative of real world examples.
+
+{% include example-list-generator.html %}
+
+{:.dragon}
+Before deriving any conclusions from the examples alone, please do check the
+[quality asssurance report](qa.html) of this implementation guide to learn about the identified
+issues and non-conformities of each of the examples.

--- a/input/pagecontent/extensions.md
+++ b/input/pagecontent/extensions.md
@@ -1,0 +1,39 @@
+The primary way to adapt the FHIR specification to specific requirements of a jurisdiction is
+through [extensions](http://hl7.org/fhir/R4/extensibility.html).
+
+### Extensions for Finnish Base Profiles
+
+This list includes the extensions for scheduling related profiles defined by HL7 Finland.
+
+<ul>
+{% include list-extensions.xhtml %}
+</ul>
+
+### Extensions in other Finnish Implementation Guides
+
+Please also note the
+[extensions listed in the Finnish Base Profiles specification](https://hl7.fi/fhir/finnish-base-profiles/extensions.html).
+
+In addition to the extensions published by HL7 Finland, there are also other extensions used in
+Finland. Most notably the ones for the national Kanta system, in several implementation guides:
+
+* [Kanta yhteiset FHIR- ja REST-rajapintamäärittelyt](https://simplifier.net/kanta-yhteiset-fhir)
+  includes definitions shared by several other Kanta implementation guides.
+* [Kanta Potilastiedon arkiston FHIR R4](https://simplifier.net/kanta-potilastiedon-arkiston-fhir-r4)
+  included specifications for patient data stored in Kanta.
+* [Kanta FHIR Prescription R4](https://simplifier.net/PrescriptionR4) includes specifications for
+  data on prescriptions
+* [Kanta sosiaalihuolto R4](https://simplifier.net/Kanta-sosiaalihuolto-R4) includes specifications
+  for data related to welfare and social affairs.
+* [Finnish PHR R4](https://simplifier.net/FinnishPHRR4) includes specifications for health and
+  wellbeing data curated by the citizens in the Finnish national Personal Health Record platform
+  Kanta PHR.
+* [Kanta tietojen kansalaiskäytön rajapinnat](https://simplifier.net/kanta-tietojen-kansalaiskayton-rajapinnat)  
+  includes specifications for citizen-centric apps accessing data in Kanta.
+
+### Other Extensions
+
+In addition to above, a
+[registry of standard extensions](http://hl7.org/fhir/R4/extensibility-registry.html) can
+be found in the FHIR specification and additional extensions may be registered on the HL7 FHIR
+registry at [http://hl7.org/fhir/registry](http://hl7.org/fhir/registry).

--- a/input/pagecontent/profiles.md
+++ b/input/pagecontent/profiles.md
@@ -1,0 +1,37 @@
+Profiles set additional constraints for the FHIR base resources and help tighter interoperability
+between systems. Read more in the [Profiling](https://hl7.org/fhir/profiling.html) section of the
+FHIR specification.
+
+### Global Profiles
+
+{% include globals-table.xhtml %}
+
+### Finnish Scheduling Profiles
+
+This is the list of profiles for FHIR resources specific to scheduling for use in Finland,
+published and maintained by HL7 Finland.
+
+{% include fragment-fi-scheduling-profiles.html %}
+
+### Other Finnish Profiles
+
+Please also note the
+[Finnish Base Profiles](https://hl7.fi/fhir/finnish-base-profiles/extensions.html) and the
+[Finnish Implementation Guide for SMART App Launch](https://hl7.fi/fhir/finnish-smart/).
+
+In addition to the profiles published by HL7 Finland, there are also other extensions used in
+Finland. Most notably the ones for the national Kanta system, in several implementation guides:
+
+* [Kanta yhteiset FHIR- ja REST-rajapintamäärittelyt](https://simplifier.net/kanta-yhteiset-fhir)
+  includes definitions shared by several other Kanta implementation guides.
+* [Kanta Potilastiedon arkiston FHIR R4](https://simplifier.net/kanta-potilastiedon-arkiston-fhir-r4)
+  included specifications for patient data stored in Kanta.
+* [Kanta FHIR Prescription R4](https://simplifier.net/PrescriptionR4) includes specifications for
+  data on prescriptions
+* [Kanta sosiaalihuolto R4](https://simplifier.net/Kanta-sosiaalihuolto-R4) includes specifications
+  for data related to welfare and social affairs.
+* [Finnish PHR R4](https://simplifier.net/FinnishPHRR4) includes specifications for health and
+  wellbeing data curated by the citizens in the Finnish national Personal Health Record platform
+  Kanta PHR.
+* [Kanta tietojen kansalaiskäytön rajapinnat](https://simplifier.net/kanta-tietojen-kansalaiskayton-rajapinnat)  
+  includes specifications for citizen-centric apps accessing data in Kanta.

--- a/input/pagecontent/terminology.md
+++ b/input/pagecontent/terminology.md
@@ -1,0 +1,27 @@
+### CodeSystems
+  
+<ul>
+{% include list-simple-codesystems.xhtml %}
+</ul>
+
+### ValueSets
+
+<ul>
+{% include list-simple-valuesets.xhtml %}
+</ul>
+
+### ConceptMaps
+
+<ul>
+{% include list-simple-conceptmaps.xhtml %}
+</ul>
+
+### NamingSystems
+
+<ul>
+{% include list-simple-namingsystems.xhtml %}
+</ul>
+
+There are also many other notable terminologies used in Finland. Please see the
+[terminology section](https://hl7.fi/fhir/finnish-base-profiles/terminology.html) of the Finnish
+FHIR Base Profiles specification. 

--- a/input/pagecontent/versions.md
+++ b/input/pagecontent/versions.md
@@ -1,0 +1,38 @@
+Version 1.0.0 is the first official release of this implementation guide. See the history of
+published versions in the
+[publication directory](https://hl7.fi/fhir/finnish-scheduling/history.html).
+
+You can track the changes between released snapshot versions through the
+Previous Version Comparison section of the [QA report](qa.html). You can also check changes
+between ballot and release versions through the
+[releases](https://github.com/fhir-fi/finnish-scheduling/releases) in GitHub.
+
+The development continues, with the intention to get definitions from this implementation guide
+into Normative level (see the
+[standards development process](https://hl7.org/fhir/versions.html#std-process) of the FHIR
+specification), and to extend the coverage of resources.
+
+Development snapshots will be published throughout the development, ballot, and maintenance cycles.
+
+### CI Build Snapshots
+The latest version of the `master` branch of the source code repository for this implementation
+guide is published at
+[https://fhir.fi/finnish-scheduling/](https://fhir.fi/finnish-scheduling/).
+
+In addition, the `master` branch and each development branch are built and published automatically
+with the build.fhir.org infrastructure. You can locate the built snapshot with
+the branch name. For instance, the latest commit to the `master` branch is published at
+[https://build.fhir.org/ig/fhir-fi/finnish-scheduling/branches/master](https://build.fhir.org/ig/fhir-fi/finnish-scheduling/branches/master).
+Or select from the
+[list of branches](https://build.fhir.org/ig/fhir-fi/finnish-scheduling/branches/).
+
+You can also browse the
+[list of all IG builds](https://fhir.github.io/auto-ig-builder/builds.html).
+
+Similarly the debug info related to the build can be found with the branch name. The build log of
+the latest commit to the `master` branch is at
+[https://build.fhir.org/ig/fhir-fi/finnish-scheduling/branches/master/build.log](https://build.fhir.org/ig/fhir-fi/finnish-scheduling/branches/master/build.log).
+
+You can also track the build info at the
+[committers/notification](https://chat.fhir.org/#narrow/stream/179297-committers.2Fnotification/topic/ig-build/)
+channel on the [chat.fhir.org](https://chat.fhir.org) Zulip forum.

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -5,7 +5,7 @@
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 id: hl7.fhir.fi.scheduling
 canonical: https://hl7.fi/fhir/finnish-scheduling
-name: Finnish Scheduling
+name: FinnishScheduling
 title: Finnish Scheduling
 description: Finnish HL7 FHIR implementation guide for scheduling, published and maintained by HL7 Finland
 status: draft # draft | active | retired | unknown
@@ -20,194 +20,32 @@ publisher:
   url: https://www.hl7.fi/
   email: mikael@sensotrend.com
 
-# The dependencies property corresponds to IG.dependsOn. The key is the
-# package id and the value is the version (or dev/current). For advanced
-# use cases, the value can be an object with keys for id, uri, and version.
-#
-# dependencies:
-#   hl7.fhir.us.core: 3.1.0
-#   hl7.fhir.us.mcode:
-#     id: mcode
-#     uri: http://hl7.org/fhir/us/mcode/ImplementationGuide/hl7.fhir.us.mcode
-#     version: 1.0.0
-#
-#
-# The pages property corresponds to IG.definition.page. SUSHI can
-# auto-generate the page list, but if the author includes pages in
-# this file, it is assumed that the author will fully manage the
-# pages section and SUSHI will not generate any page entries.
-# The page file name is used as the key. If title is not provided,
-# then the title will be generated from the file name.  If a
-# generation value is not provided, it will be inferred from the
-# file name extension.  Any subproperties that are valid filenames
-# with supported extensions (e.g., .md/.xml) will be treated as
-# sub-pages.
-#
-# pages:
-#   index.md:
-#     title: Example Home
-#   implementation.xml:
-#   examples.xml:
-#     title: Examples Overview
-#     simpleExamples.xml:
-#     complexExamples.xml:
-#
-#
-# The parameters property represents IG.definition.parameter. Rather
-# than a list of code/value pairs (as in the ImplementationGuide
-# resource), the code is the YAML key. If a parameter allows repeating
-# values, the value in the YAML should be a sequence/array.
-# For parameters defined by core FHIR see:
-# http://build.fhir.org/codesystem-guide-parameter-code.html
-# For parameters defined by the FHIR Tools IG see:
-# http://build.fhir.org/ig/FHIR/fhir-tools-ig/branches/master/CodeSystem-ig-parameters.html
-#
-# parameters:
-#   excludettl: true
-#   validation: [allow-any-extensions, no-broken-links]
-#
-# ╭────────────────────────────────────────────menu.xml────────────────────────────────────────────╮
-# │ The menu property will be used to generate the input/menu.xml file. The menu is represented    │
-# │ as a simple structure where the YAML key is the menu item name and the value is the URL.       │
-# │ The IG publisher currently only supports one level deep on sub-menus. To provide a             │
-# │ custom menu.xml file, do not include this property and include a `menu.xml` file in            │
-# │ input/includes. To use a provided input/includes/menu.xml file, delete the "menu"              │
-# │ property below.                                                                                │
-# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+dependencies:
+  hl7.fhir.fi.base: latest
+
+pages:
+  index.md:
+    title: Home
+  profiles.md:
+    title: Profiles
+  extensions.md:
+    title: Extensions
+  terminology.md:
+    title: Terminology
+  examples.md:
+    title: Examples
+  downloads.md:
+    title: Downloads
+  versions.md:
+    title: Version History
+
+parameters: 
+  ipa-comparison: "{last}" # "{current}" | "{last}"
+
 menu:
   Home: index.html
-  Artifacts: artifacts.html
-
-# ╭───────────────────────────Less Common Implementation Guide Properties──────────────────────────╮
-# │  Uncomment the properties below to configure additional properties on the ImplementationGuide  │
-# │  resource. These properties are less commonly needed than those above.                         │
-# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
-#
-# Those who need more control or want to add additional details to the contact values can use
-# contact directly and follow the format outlined in the ImplementationGuide resource and
-# ContactDetail.
-#
-# contact:
-#   - name: Bob Smith
-#     telecom:
-#       - system: email # phone | fax | email | pager | url | sms | other
-#         value: bobsmith@example.org
-#         use: work
-#
-#
-# The global property corresponds to the IG.global property, but it
-# uses the type as the YAML key and the profile as its value. Since
-# FHIR does not explicitly disallow more than one profile per type,
-# neither do we; the value can be a single profile URL or an array
-# of profile URLs. If a value is an id or name, SUSHI will replace
-# it with the correct canonical when generating the IG JSON.
-#
-# global:
-#   Patient: http://example.org/fhir/StructureDefinition/my-patient-profile
-#   Encounter: http://example.org/fhir/StructureDefinition/my-encounter-profile
-#
-#
-# The resources property corresponds to IG.definition.resource.
-# SUSHI can auto-generate all of the resource entries based on
-# the FSH definitions and/or information in any user-provided
-# JSON or XML resource files. If the generated entries are not
-# sufficient or complete, however, the author can add entries
-# here. If the reference matches a generated entry, it will
-# replace the generated entry. If it doesn't match any generated
-# entries, it will be added to the generated entries. The format
-# follows IG.definition.resource with the following differences:
-#   * use IG.definition.resource.reference.reference as the YAML key.
-#   * if the key is an id or name, SUSHI will replace it with the
-#     correct URL when generating the IG JSON.
-#   * specify "omit" to omit a FSH-generated resource from the
-#     resource list.
-#   * if the exampleCanonical is an id or name, SUSHI will replace
-#     it with the correct canonical when generating the IG JSON.
-#   * groupingId can be used, but top-level groups syntax may be a
-#     better option (see below).
-# The following are simple examples to demonstrate what this might
-# look like:
-#
-# resources:
-#   Patient/my-example-patient:
-#     name: My Example Patient
-#     description: An example Patient
-#     exampleBoolean: true
-#   Patient/bad-example: omit
-#
-#
-# Groups can control certain aspects of the IG generation.  The IG
-# documentation recommends that authors use the default groups that
-# are provided by the templating framework, but if authors want to
-# use their own instead, they can use the mechanism below.  This will
-# create IG.definition.grouping entries and associate the individual
-# resource entries with the corresponding groupIds. If a resource
-# is specified by id or name, SUSHI will replace it with the correct
-# URL when generating the IG JSON.
-#
-# groups:
-#   GroupA:
-#     name: Group A
-#     description: The Alpha Group
-#     resources:
-#     - StructureDefinition/animal-patient
-#     - StructureDefinition/arm-procedure
-#   GroupB:
-#     name: Group B
-#     description: The Beta Group
-#     resources:
-#     - StructureDefinition/bark-control
-#     - StructureDefinition/bee-sting
-#
-#
-# The ImplementationGuide resource defines several other properties
-# not represented above. These properties can be used as-is and
-# should follow the format defined in ImplementationGuide:
-# * date
-# * meta
-# * implicitRules
-# * language
-# * text
-# * contained
-# * extension
-# * modifierExtension
-# * experimental
-# * useContext
-# * copyright
-# * packageId
-#
-#
-# ╭──────────────────────────────────────────SUSHI flags───────────────────────────────────────────╮
-# │  The flags below configure aspects of how SUSHI processes FSH.                                 │
-# ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
-# The FSHOnly flag indicates if only FSH resources should be exported.
-# If set to true, no IG related content will be generated.
-# The default value for this property is false.
-#
-# FSHOnly: false
-#
-#
-# When set to true, the "short" and "definition" field on the root element of an Extension will
-# be set to the "Title" and "Description" of that Extension. Default is true.
-#
-# applyExtensionMetadataToRoot: true
-#
-#
-# The instanceOptions property is used to configure certain aspects of how SUSHI processes instances.
-# See the individual option definitions below for more detail.
-#
-instanceOptions:
-  # When set to true, slices must be referred to by name and not only by a numeric index in order to be used
-  # in an Instance's assignment rule. All slices appear in the order in which they are specified in FSH rules.
-  # While SUSHI defaults to false for legacy reasons, manualSliceOrding is recommended for new projects.
-  manualSliceOrdering: true # true | false
-  # Determines for which types of Instances SUSHI will automatically set meta.profile
-  # if InstanceOf references a profile:
-  #
-  # setMetaProfile: always # always | never | inline-only | standalone-only
-  #
-  #
-  # Determines for which types of Instances SUSHI will automatically set id
-  # if InstanceOf references a profile:
-  #
-  # setId: always # always | standalone-only
+  Profiles: profiles.html
+  Extensions: extensions.html
+  Terminology: terminology.html
+  Examples: examples.html
+  Downloads: downloads.html


### PR DESCRIPTION
Include menu items for profiles, extensions, terminology, examples, and downloads.

Remove manually added url's from FiScheduling* profiles. The URL is added by sushi automatically based on the config.