### PR TITLE
Relax maximum cardinalities

### DIFF
--- a/input/fsh/profiles/FiSchedulingAppointment.fsh
+++ b/input/fsh/profiles/FiSchedulingAppointment.fsh
@@ -58,18 +58,16 @@ Description: "Base profile for appointment (**ajanvaraus**) in Finnish Schedulin
 * cancelationReason ^requirements = "19.1 Ajanvarauksen perumisen tai siirtämisen syy\r\n\r\nMandatory, if cancellation status is equivalent to \"Siirretty\" or \"Peruttu\""
 * cancelationReason.coding.system = "urn:oid:1.2.246.537.6.126.2008" (exactly)
 * cancelationReason.coding.system ^short = "THL - Palvelutapahtuman peruuntumisen tai siirtymisen syy"
-* serviceCategory ..1
 * serviceCategory ^requirements = "71.1 Palvelun luokka"
 * serviceCategory.coding.system = "urn:oid:1.2.246.537.6.88.2008" (exactly)
 * serviceCategory.coding.system ^short = "AR/YDIN - Palvelutapahtumaluokitus"
 * serviceCategory.coding.system ^definition = "hl7fi: koodilla ilmaistu tieto palveluluokasta, johon ajanvaraus kohdistuu Huom. Palveluluokka ilmaistaan THL - Sosiaali- ja terveyspalvelujen luokituksen avulla."
-* serviceType 1..1
+* serviceType 1..*
 * serviceType ^requirements = "71 Palvelun nimi"
 * serviceType.coding.system = "urn:oid:1.2.246.537.6.49.201501" (exactly)
 * serviceType.coding.system ^short = "THL - Sosiaali- ja terveysalan palvelunimikkeistö"
 * serviceType.coding.system ^comment = "hl7fi: koodilla ilmaistu tieto palvelusta, johon ajanvaraus kohdistuu Huom. Palvelun nimi ilmaistaan THL - Sosiaali- ja terveysalan palvelunimikkeistön avulla.\r\n\r\nThe URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously."
 * serviceType.coding.system ^requirements = "71 Palvelun nimi"
-* specialty ..0
 * appointmentType ^requirements = "72 Asiointitapa"
 * appointmentType.coding.system = "1.2.246.537.6.884.2015" (exactly)
 * appointmentType.coding.system ^short = "hl7fi: asiointitapa"
@@ -94,14 +92,8 @@ Description: "Base profile for appointment (**ajanvaraus**) in Finnish Schedulin
 * reasonReference ^requirements = "56 kuvaus oireista/vaivasta ja \r\n57 riskitiedot (Condition/Note)"
 * reasonReference ^type.aggregation = #contained
 * reasonReference.type = "Condition" (exactly)
-* reasonReference.identifier ..0
-* reasonReference.display ..0
-* priority ..0
-* description ..0
-* supportingInformation ..0
 * start ^requirements = "86 Aikaväli"
 * end ^requirements = "86 Aikaväli"
-* minutesDuration ..0
 * created ^requirements = "38 Merkinnän kirjausaika"
 * comment ^short = "hl7fi: asiakkaalle tai ajanvarauksen katselijalle tarkoitettu vapaamuotoinen lisätieto"
 * comment ^definition = "hl7fi: asiakkaalle tai ajanvarauksen katselijalle tarkoitettu vapaamuotoinen lisätieto"
@@ -115,6 +107,4 @@ Description: "Base profile for appointment (**ajanvaraus**) in Finnish Schedulin
 // * patientInstruction.extension[PatientInstructionURL] only PatientInstructionURLExtension
 // * patientInstruction.extension[PatientInstructionURL] ^sliceName = "PatientInstructionURL"
 // * patientInstruction.extension[PatientInstructionURL] ^requirements = "100.1 Linkki potilasohjeeseen"
-* basedOn ..0
-* requestedPeriod ..1
 * requestedPeriod ^requirements = "35 Ajankohta, jolloin ajanvaraus ohjeistettu tehtäväksi"

--- a/input/fsh/profiles/FiSchedulingHealthcareService.fsh
+++ b/input/fsh/profiles/FiSchedulingHealthcareService.fsh
@@ -3,15 +3,18 @@ Parent: HealthcareService
 Id: fi-scheduling-healthcare-service
 Description: "Finnish profile for healthcare service."
 * ^url = "http://hl7.fi/fhir/StructureDefinition/FiSchedulingHealthcareService"
-* category ..1
-* category ^requirements = "71.1 Palvelun luokka"
-* category.coding.system = "urn:oid:1.2.246.537.6.88.2008" (exactly)
-* category.coding.system ^short = "AR/YDIN - Palvelutapahtumaluokitus"
-* type 1..1
+// We could create a slicing definition that demands that one of the categories is from
+// Palvelutapahtumaluokitus. Let's see if we want even this. Anyway, it is not appropriate to not
+// allow for other categories to be present.
+// * category ..1
+// * category ^requirements = "71.1 Palvelun luokka"
+// * category.coding.system = "urn:oid:1.2.246.537.6.88.2008" (exactly)
+// * category.coding.system ^short = "AR/YDIN - Palvelutapahtumaluokitus"
+* type 1..
 * type ^requirements = "hl7fi: 71 Palvelun nimi"
 * type.coding.system = "urn:oid:1.2.246.537.6.49.201501" (exactly)
 * type.coding.system ^short = "THL - Sosiaali- ja terveysalan palvelunimikkeistö"
-* specialty ..1
+* specialty ..
 * specialty ^definition = "hl7fi: for service specific needs to eg pinpoint the service type like occupational healthcare, orthopedics\r\n\r\n--\r\n\r\nCollection of specialties handled by the service site. This is more of a medical term."
 * specialty.coding.system = "urn:oid:1.2.246.537.6.24.2003" (exactly)
 * specialty.coding.system ^short = "Hilmo - Terveydenhuollon erikoisalat versio"

--- a/input/fsh/profiles/FiSchedulingLocation.fsh
+++ b/input/fsh/profiles/FiSchedulingLocation.fsh
@@ -3,34 +3,19 @@ Parent: Location
 Id: fi-scheduling-location
 Description: "Details for schedulable location"
 * ^url = "http://hl7.fi/fhir/StructureDefinition/FiSchedulingLocation"
-* identifier 1..1
+* identifier 1..
 * identifier ^requirements = "79 Palveluntoteuttaja tai XX Palveluntoteuttajan palvelupisteen tunniste"
 * identifier.value ^requirements = "79 Palveluntoteuttaja tai XX Palveluntoteuttajan palvelupisteen tunniste"
 * name ^requirements = "80 Palveluntoteuttajan nimi"
-* mode ..0
 * telecom ^requirements = "83 Yhteystiedot"
 * telecom.system 1..
 * telecom.value 1..
-* telecom.use ..0
-* telecom.rank ..0
-* telecom.period ..0
-* address.use ..0
-* address.type ..0
 * address.text ^requirements = "81.1 Palvelupisteen sijainnin lisätiedot"
 * address.line ^requirements = "81 Palvelupisteen sijainti"
 * address.city ^requirements = "81 Palvelupisteen sijainti"
-* address.district ..0
-* address.state ..0
 * address.postalCode ^requirements = "81 Palvelupisteen sijainti"
 * address.country ^requirements = "81 Palvelupisteen sijainti"
-* address.period ..0
-* physicalType ..0
 * managingOrganization ^requirements = "77 Palveluntuottaja\r\n78 Palveluntuottajan nimi"
 * managingOrganization.identifier ^requirements = "77 Palveluntuottaja \r\n\r\nTHL - SOTE-organisaatiorekisteri 1.2.246.537.6.202.2008\r\nValvira - Terveydenhuollon itsenäiset ammatinharjoittajat 1.2.246.537.6.203.2014"
-* managingOrganization.identifier.use ..0
-* managingOrganization.identifier.type ..0
 * managingOrganization.identifier.system 1..
 * managingOrganization.identifier.value 1..
-* managingOrganization.identifier.period ..0
-* managingOrganization.identifier.assigner ..0
-* endpoint ..0

--- a/input/fsh/profiles/FiSchedulingPatient.fsh
+++ b/input/fsh/profiles/FiSchedulingPatient.fsh
@@ -7,7 +7,7 @@ Description: "Resource profile for patient to be used in Finnish social and heal
 * extension ^slicing.discriminator.path = "url"
 * extension ^slicing.rules = #open
 * extension contains HomeMunicipalityExtension named homeMunicipality 0..*
-* identifier 1..2
+* identifier 1..
 * identifier ^slicing.discriminator.type = #value
 * identifier ^slicing.discriminator.path = "use"
 * identifier ^slicing.rules = #open
@@ -18,45 +18,23 @@ Description: "Resource profile for patient to be used in Finnish social and heal
 * identifier[sliceIdentifierOfficial].use = #official (exactly)
 * identifier[sliceIdentifierOfficial].use ^definition = "Virallinen henkilötunnus"
 * identifier[sliceIdentifierOfficial].use ^requirements = "Virallinen henkilötunnus"
-* identifier[sliceIdentifierOfficial].type ..0
 * identifier[sliceIdentifierOfficial].system 1..
 * identifier[sliceIdentifierOfficial].system = "urn:oid:1.2.246.21" (exactly)
 * identifier[sliceIdentifierOfficial].value 1..
-* identifier[sliceIdentifierOfficial].period ..0
-* identifier[sliceIdentifierOfficial].assigner ..0
 * identifier[sliceIdentifierTemp].use = #temp (exactly)
-* identifier[sliceIdentifierTemp].type ..0
 * identifier[sliceIdentifierTemp].system 1..
 * identifier[sliceIdentifierTemp].value 1..
-* identifier[sliceIdentifierTemp].period ..0
-* identifier[sliceIdentifierTemp].assigner ..0
-* active ..0
-* name 1..1
+* name 1..
 * name ^requirements = "52 Asiakkaan nimi"
-* name.period ..0
 * telecom ^requirements = "Puhelinnumero ja sähköposti"
-* deceased[x] ..0
-* address ..1
 * address ^requirements = "54 Asiakkaan osoitetiedot"
-* address.type ..0
-* address.district ..0
-* address.state ..0
-* address.period ..0
-* maritalStatus ..0
-* multipleBirth[x] ..0
-* photo ..0
-* contact.relationship ..1
 * contact.relationship ^requirements = "61 Yhteyshenkilön tyyppi \r\nUsed to determine which contact person is the most relevant to approach, depending on circumstances."
-* contact.relationship.coding.system = "urn:oid:1.2.245.537.6.882" (exactly)
+// We could create a slicing definition that demands that one of the codings is from
+// Ajanvaraus - Yhteyshenkilön tyyppi (which is 1.2.246.537.6.882, by the way).
+// Anyway, it is not appropriate to not allow for other codings to be present.
+// * contact.relationship.coding.system = "urn:oid:1.2.245.537.6.882" (exactly)
 * contact.name ^requirements = "62 Yhteyshenkilön nimi\r\nContact persons need to be identified by name, but it is uncommon to need details about multiple other names for that contact person."
-* contact.name.period ..0
 * contact.telecom ^requirements = "64 Yhteyshenkilön yhteystieto\r\nPeople have (primary) ways to contact them in some way such as phone, email."
-* contact.telecom.period ..0
 * contact.address ^requirements = "63 Yhteyshenkilön osoitetiedot\r\nNeed to keep track where the contact person can be contacted per postal mail or visited."
-* contact.gender ..0
-* contact.organization ..0
-* contact.period ..0
-* communication.language.coding.system = "urn:oid:1.2.246.537.5.40175.2008" (exactly)
-* generalPractitioner ..0
-* managingOrganization ..0
-* link ..0
+// Code set 1.2.246.537.5.40175 is essentially ISO 639. Other expressions of that standard should be allowed too.
+// * communication.language.coding.system = "urn:oid:1.2.246.537.5.40175.2008" (exactly)

--- a/input/fsh/profiles/FiSchedulingPractitioner.fsh
+++ b/input/fsh/profiles/FiSchedulingPractitioner.fsh
@@ -3,7 +3,7 @@ Parent: Practitioner
 Id: fi-scheduling-practitioner
 Description: "Practitioner details for Finnish Scheduling (including various Finnish social and healthcare professional id types)"
 * ^url = "http://hl7.fi/fhir/StructureDefinition/FiSchedulingPractitioner"
-* identifier 1..1
+* identifier 1..
 * identifier ^slicing.discriminator.type = #value
 * identifier ^slicing.discriminator.path = "system"
 * identifier ^slicing.rules = #open
@@ -11,35 +11,20 @@ Description: "Practitioner details for Finnish Scheduling (including various Fin
     sliceIdentifierOfficial 0..1 and
     sliceIdentifierTerhikki 0..1 and
     sliceIdentifierVRK 0..1
-* identifier[sliceIdentifierOfficial].use 1..
+* identifier[sliceIdentifierOfficial].use 1.. // Why do we allow for more uses, if the value is fixed?
 * identifier[sliceIdentifierOfficial].use = #official (exactly)
-* identifier[sliceIdentifierOfficial].type ..0
-* identifier[sliceIdentifierOfficial].system 1..
+* identifier[sliceIdentifierOfficial].system 1.. // Why do we allow for more systems, if the value is fixed?
 * identifier[sliceIdentifierOfficial].system = "urn:oid:1.2.246.21" (exactly)
 * identifier[sliceIdentifierOfficial].system ^requirements = "Ammattihenkilön hetu\r\n\r\nThere are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers."
 * identifier[sliceIdentifierOfficial].value 1..
-* identifier[sliceIdentifierOfficial].period ..0
-* identifier[sliceIdentifierOfficial].assigner ..0
-* identifier[sliceIdentifierTerhikki].use ..0
-* identifier[sliceIdentifierTerhikki].type ..0
 * identifier[sliceIdentifierTerhikki].system 1..
 * identifier[sliceIdentifierTerhikki].system = "urn:oid:1.2.246.537.26" (exactly)
 * identifier[sliceIdentifierTerhikki].system ^requirements = "Terveydenhuollon ammattihenkilöiden keskusrekisteirn tunnus\r\n\r\nThere are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers."
 * identifier[sliceIdentifierTerhikki].value 1..
-* identifier[sliceIdentifierTerhikki].period ..0
-* identifier[sliceIdentifierTerhikki].assigner ..0
-* identifier[sliceIdentifierVRK].use ..0
-* identifier[sliceIdentifierVRK].type ..0
 * identifier[sliceIdentifierVRK].system 1..
 * identifier[sliceIdentifierVRK].system = "urn:oid:1.2.246.537.29" (exactly)
 * identifier[sliceIdentifierVRK].system ^requirements = "VRK:n yksilöivä tunnus\r\n\r\nThere are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers."
 * identifier[sliceIdentifierVRK].value 1..
-* identifier[sliceIdentifierVRK].period ..0
-* identifier[sliceIdentifierVRK].assigner ..0
-* active ..0
-* name ..1
-* address ..0
-* photo ..1
-* qualification ..0
 * communication ^requirements = "Kielet, jolla kykenee palvelemaan\r\n\r\nKnowing which language a practitioner speaks can help in facilitating communication with patients."
-* communication.coding.system = "1.2.246.537.5.40175.2008" (exactly)
+// Code set 1.2.246.537.5.40175 is essentially ISO 639. Other expressions of that standard should be allowed too.
+// * communication.coding.system = "1.2.246.537.5.40175.2008" (exactly)

--- a/input/fsh/profiles/FiSchedulingPractitionerRole.fsh
+++ b/input/fsh/profiles/FiSchedulingPractitionerRole.fsh
@@ -3,17 +3,9 @@ Parent: PractitionerRole
 Id: fi-scheduling-practitioner-role
 Description: "Role information for the practitioner."
 * ^url = "http://hl7.fi/fhir/StructureDefinition/FiSchedulingPractitionerRole"
-* identifier ..0
-* active ..0
-* period ..0
-* code ..0
 * specialty ^requirements = "Hilmo - Terveydenhuollon erikoisalat"
-* specialty.coding.system = "urn:oid:1.2.246.537.6.24.2003" (exactly)
+// We could create a slicing definition that demands that one of the categories is from
+// Hilmo - Terveydenhuollon erikoisalat.
+// However, it is not appropriate to not allow for other coding systems to be present.
+// * specialty.coding.system = "urn:oid:1.2.246.537.6.24.2003" (exactly)
 * location ^requirements = "Työskentely-yksikkö"
-* location.identifier.use ..0
-* location.identifier.type ..0
-* telecom ..0
-* availableTime ..0
-* notAvailable ..0
-* availabilityExceptions ..0
-* endpoint ..0

--- a/input/fsh/profiles/FiSchedulingSchedule.fsh
+++ b/input/fsh/profiles/FiSchedulingSchedule.fsh
@@ -3,16 +3,20 @@ Parent: Schedule
 Id: fi-scheduling-schedule
 Description: "Finnish profile for Schedule"
 * ^url = "http://hl7.fi/fhir/StructureDefinition/FiSchedulingSchedule"
-* identifier 1..1
+* identifier 1..
 * identifier.use 0..
 * identifier.period 0..
 * identifier.assigner 0..
-* serviceCategory ..1
 * serviceCategory ^requirements = "71.1 Palvelun luokka"
-* serviceCategory.coding.system = "urn:oid:1.2.246.537.6.88.2008" (exactly)
+// We could create a slicing definition that demands that one of the categories is from
+// AR/YDIN - Palvelutapahtumaluokitus. Let's see if we want even this.
+// Anyway, it is not appropriate to not allow for other categories to be present.
+// * serviceCategory.coding.system = "urn:oid:1.2.246.537.6.88.2008" (exactly)
 * serviceCategory.coding.system ^short = "AR/YDIN - Palvelutapahtumaluokitus"
-* serviceType ..1
-* serviceType ^requirements = "71 Palvelun nimi"
-* serviceType.coding.system = "urn:oid:1.2.246.537.6.49.201501" (exactly)
-* serviceType.coding.system ^short = "THL - Sosiaali- ja terveysalan palvelunimikkeistö"
-* specialty ..0
+// We could create a slicing definition that demands that one of the service types is from
+// THL - Sosiaali- ja terveysalan palvelunimikkeistö. Let's see if we want even this.
+// Anyway, it is not appropriate to not allow for other types to be present.
+// * serviceType ..1
+// * serviceType ^requirements = "71 Palvelun nimi"
+// * serviceType.coding.system = "urn:oid:1.2.246.537.6.49.201501" (exactly)
+// * serviceType.coding.system ^short = "THL - Sosiaali- ja terveysalan palvelunimikkeistö"

--- a/input/fsh/profiles/FiSchedulingSlot.fsh
+++ b/input/fsh/profiles/FiSchedulingSlot.fsh
@@ -3,20 +3,20 @@ Parent: Slot
 Id: fi-scheduling-slot
 Description: "Finnish profile for Slot"
 * ^url = "http://hl7.fi/fhir/StructureDefinition/FiSchedulingSlot"
-* identifier ..1
-* identifier.use 0..
-* identifier.period 0..
-* identifier.assigner 0..
-* serviceCategory ..1
 * serviceCategory ^requirements = "71.1 Palvelun luokka"
-* serviceCategory.coding.system = "urn:oid:1.2.246.537.6.88.2008" (exactly)
+// We could create a slicing definition that demands that one of the categories is from
+// AR/YDIN - Palvelutapahtumaluokitus.
+// Anyway, it is not appropriate to not allow for other categories to be present.
+//* serviceCategory.coding.system = "urn:oid:1.2.246.537.6.88.2008" (exactly)
 * serviceCategory.coding.system ^short = "AR/YDIN - Palvelutapahtumaluokitus"
-* serviceType 1..1
+* serviceType 1..
 * serviceType ^requirements = "71 Palvelun nimi"
-* serviceType.coding.system = "urn:oid:1.2.246.537.6.49.201501" (exactly)
+//* serviceType.coding.system = "urn:oid:1.2.246.537.6.49.201501" (exactly)
 * serviceType.coding.system ^short = "THL - Sosiaali- ja terveysalan palvelunimikkeistö"
-* specialty ..0
 * appointmentType ^requirements = "72 Asiointitapa"
-* appointmentType.coding ..1
-* appointmentType.coding.system = "urn:oid:1.2.246.537.6.884.2015" (exactly)
-* appointmentType.coding.system ^short = "THL - Asiointitapa"
+// We could create a slicing definition that demands that one of the codings is from
+// THL - Asiointitapa.
+// Anyway, it is not appropriate to not allow for other types to be present.
+// * appointmentType.coding ..1
+// * appointmentType.coding.system = "urn:oid:1.2.246.537.6.884.2015" (exactly)
+// * appointmentType.coding.system ^short = "THL - Asiointitapa"


### PR DESCRIPTION
In most cases, it is not appropriate to limit the upper limit of cardinalities. It enhances interoperability if systems providing information are able to provide several codings of the element. Also, in some use cases you may need more instances of an element.

The receiving system is free to ignore the elements it does not support (as long as they are not modifier elements, of course).

We may well want to create profiles where we say that an element with a certain coding needs to be present. But we should not mandate that no other elements or codings are allowed to be present as well. This should be done by slicing.