### PR TITLE
Make the IG Compile Again

### DIFF
--- a/input/fsh/profiles/FiSchedulingAppointment.fsh
+++ b/input/fsh/profiles/FiSchedulingAppointment.fsh
@@ -52,7 +52,7 @@ Description: "Base profile for appointment (*ajanvaraus*) in Finnish Scheduling 
 // * identifier.assigner 0..
 * status ^comment = "hl7fi: Requires mapping to *Ajanvarauksen tila* code set (1.2.246.537.6.881.201501). Other mappings ok apart from \"siirretty\" (rescheduled) ja \"suunniteltu\". \r\n\r\nIf the Appointment's status is \"cancelled\" then all participants are expected to have their calendars released for the appointment period, and as such any Slots that were marked as BUSY can be re-set to FREE.\n\nThis element is labeled as a modifier because the status contains the code entered-in-error that mark the Appointment as not currently valid."
 * status ^requirements = "19 Ajanvarauksen tila"
-* status from $codeserver-booking-status-page (required)
+// * status from $codeserver-booking-status-page (required)
 * status ^short = "suunniteltu | tilattu | varattu | peruttu | siirretty | alkanut | toteutunut | ehdotettu | saapumatta"
 * cancelationReason ^requirements = "19.1 Ajanvarauksen perumisen tai siirtämisen syy\r\n\r\nMandatory, if cancellation status is equivalent to \"Siirretty\" or \"Peruttu\""
 * cancelationReason.coding.system = "urn:oid:1.2.246.537.6.126.2008" (exactly)

--- a/input/fsh/profiles/FiSchedulingHealthcareService.fsh
+++ b/input/fsh/profiles/FiSchedulingHealthcareService.fsh
@@ -13,7 +13,6 @@ Description: "Finnish profile for healthcare service."
 * type ^requirements = "hl7fi: 71 Palvelun nimi"
 * type.coding.system = "urn:oid:1.2.246.537.6.49.201501" (exactly)
 * type.coding.system ^short = "THL - Sosiaali- ja terveysalan palvelunimikkeistö"
-* specialty ..
 * specialty ^definition = "hl7fi: for service specific needs to eg pinpoint the service type like occupational healthcare, orthopedics\r\n\r\n--\r\n\r\nCollection of specialties handled by the service site. This is more of a medical term."
 * specialty.coding.system = "urn:oid:1.2.246.537.6.24.2003" (exactly)
 * specialty.coding.system ^short = "Hilmo - Terveydenhuollon erikoisalat versio"

--- a/input/fsh/profiles/FinnishAppointmentAppointment.fsh
+++ b/input/fsh/profiles/FinnishAppointmentAppointment.fsh
@@ -17,7 +17,7 @@ Description: "Profile for appointment (ajanvaraus) in Finnish Scheduling environ
     ChildAppointment named ChildAppointment 0..*
 * extension[ParentAppointment] ^requirements = "12 Pääajanvaraus"
 * extension[AppointmentMutability] ^requirements = "95 Peruttavissa\r\n96 Siirrettävissä\r\n96.1 Peruutuksen tai siirron aikaraja"
-* status from $codeserver-booking-status-page (required)
+// * status from $codeserver-booking-status-page (required)
 * status ^short = "suunniteltu | tilattu | varattu | peruttu | siirretty | alkanut | toteutunut | ehdotettu | saapumatta"
 * cancelationReason.coding.system = "urn:oid:1.2.246.537.6.126.2008" (exactly)
 * cancelationReason.coding.system ^short = "THL - Palvelutapahtuman peruuntumisen tai siirtymisen syy"


### PR DESCRIPTION
Fix a merge conflict artifact and remove reference to code server page.

Could have removed the alias for `$codeserver-booking-status-page` too, but did not do it yet. Let's keep it as a reminder that this is something we should look at and get a good resolution on. See the comment on be831f6ed033d5c515e7b2d427ea3e43ec526207 for some details.