### PR TITLE
Update publish script

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,1 +1,1 @@
-java -jar input-cache/publisher.jar -go-publish -source $(pwd) -web https://hl7.fi/fhir -registry $(pwd)/../ig-registry/fhir-ig-list.json -history $(pwd)/../fhir-ig-history-template/ -templates $(pwd)/../ig-template-fhir-fi -temp $(pwd)/temp
+java -jar input-cache/publisher.jar -go-publish -source $(pwd) -web https://hl7.fi/fhir -registry $(pwd)/../ig-registry/fhir-ig-list.json -history $(pwd)/../fhir-ig-history-template/ -templates $(pwd)/../history-template-fhir-fi -temp $(pwd)/temp


### PR DESCRIPTION
Templates required for the history page by the ig publisher are different from the IG template.

I created a new repo for these, and removed the files from the ig template repo.

This should enable the auto-build infrastructure to run again.