### PR TITLE
Add a concept map for appointment status

### DIFF
--- a/input/fsh/mappings/appointment-status-concept-map.fsh
+++ b/input/fsh/mappings/appointment-status-concept-map.fsh
@@ -1,0 +1,181 @@
+Instance: appointment-status-concept-map
+InstanceOf: ConceptMap
+Title: "FHIR Appointment status codes and Ajanvaraus - Ajanvarauksen tila"
+Description: "Mapping between the Finnish logical model [*Ajanvaraus - Ajanvarauksen tila*](https://koodistopalvelu.kanta.fi/codeserver/pages/classification-view-page.xhtml?classificationKey=1943) (oid `1.2.246.537.6.881`) and FHIR Appoinment status codes, in both directions."
+Usage: #definition
+* status = #draft
+* sourceUri = "https://koodistopalvelu.kanta.fi/codeserver/pages/classification-view-page.xhtml?classificationKey=1943"
+* targetCanonical = "http://hl7.org/fhir/appointmentstatus"
+* group
+  * source = "https://koodistopalvelu.kanta.fi/codeserver/pages/classification-view-page.xhtml?classificationKey=1943"
+  * target = "http://hl7.org/fhir/appointmentstatus"
+  * element
+    * code = #1
+    * display = "Suunniteltu"
+    * target
+      * code = #waitlist
+      * display = "Waitlisted"
+      * equivalence = #equivalent
+      * comment = "In FHIR there is no distinction between Suunniteltu and Tilattu. The distinction is that in Tilattu the service provider has been identified."
+  * element[+]
+    * code = #2
+    * display = "Tilattu"
+    * target
+      * code = #waitlist
+      * display = "Waitlisted"
+      * equivalence = #wider
+      * comment = "In FHIR there is no distinction between Suunniteltu and Tilattu. The distinction is that in Tilattu the service provider has been identified."
+  * element[+]
+    * code = #3
+    * display = "Varattu"
+    * target
+      * code = #booked
+      * display = "Booked"
+      * equivalence = #equal
+  * element[+]
+    * code = #4
+    * display = "Peruttu"
+    * target
+      * code = #cancelled
+      * display = "Cancelled"
+      * equivalence = #equal
+  * element[+]
+    * code = #5
+    * display = "Siirretty"
+    * target
+      * code = #cancelled
+      * display = "Cancelled"
+      * equivalence = #unmatched
+      * comment = "There is no status for rescheduled appointments in FHIR. This code SHOULD be mapped to cancelled, if required. Note that this code is deprecated."
+  * element[+]
+    * code = #6
+    * display = "Alkanut"
+    * target
+      * code = #arrived
+      * display = "Arrived"
+      * equivalence = #inexact
+      * comment = "There is no status for an appointment being in process in FHIR. In FHIR this information is tracked with the status of the Encounter resource."
+  * element[+]
+    * code = #7
+    * display = "Toteutunut"
+    * target
+      * code = #fullfilled
+      * display = "Fulfilled"
+      * equivalence = #inexact
+      * comment = "There is no status for an appointment being in process in FHIR. In FHIR this information is tracked with the status of the Encounter resource."
+  * element[+]
+    * code = #8
+    * display = "Ehdotettu"
+    * target[0]
+      * code = #proposed
+      * display = "Proposed"
+      * equivalence = #narrower
+      * comment = "The code proposed can be used to highlight that none of the participants have finalized their acceptance, or that there is still uncertainty about the time."
+    * target[+]
+      * code = #pending
+      * display = "Pending"
+      * equivalence = #equivalent
+      * comment = "The code pending is a  more generic match to Ehdotettu."
+  * element[+]
+    * code = #9
+    * display = "Saapumatta"
+    * target
+      * code = #noshow
+      * display = "No Show"
+      * equivalence = #equal
+  * element[+]
+    * code = #10
+    * display = "Ilmoittautunut"
+    * target
+      * code = #checked-in
+      * display = "Checked In"
+      * equivalence = #equal
+* group[+]
+  * source = "http://hl7.org/fhir/appointmentstatus"
+  * target = "https://koodistopalvelu.kanta.fi/codeserver/pages/classification-view-page.xhtml?classificationKey=1943"
+  * element
+    * code = #proposed
+    * display = "Proposed"
+    * target
+      * code = #8
+      * display = "Ehdotettu"
+      * equivalence = #wider
+      * comment = "The Finnish logical model does not separate between proposed and pending codes"
+  * element[+]
+    * code = #pending
+    * display = "Pending"
+    * target
+      * code = #8
+      * display = "Ehdotettu"
+      * equivalence = #wider
+      * comment = "The Finnish logical model does not separate between proposed and pending codes"
+  * element[+]
+    * code = #booked
+    * display = "Booked"
+    * target
+      * code = #3
+      * display = "Varattu"
+      * equivalence = #equal
+  * element[+]
+    * code = #arrived
+    * display = "Arrived"
+    * target
+      * code = #10
+      * display = "Ilmoittautunut"
+      * equivalence = #wider
+      * comment = "The Finnish logical model does not separate between arrived and checked-in codes"
+  * element[+]
+    * code = #fulfilled
+    * display = "Fulfilled"
+    * target
+      * code = #6
+      * display = "Alkanut"
+      * equivalence = #narrower
+      * comment = "Use Alkanut when the encounter of this Appointment is in progress"
+    * target
+      * code = #7
+      * display = "Toteutunut"
+      * equivalence = #narrower
+      * comment = "Use Toteutunut when the service related to the Appointment has begun or is completed"
+  * element[+]
+    * code = #cancelled
+    * display = "Cancelled"
+    * target
+      * code = #4
+      * display = "Peruttu"
+      * equivalence = #equal
+  * element[+]
+    * code = #noshow
+    * display = "No Show"
+    * target
+      * code = #9
+      * display = "Saapumatta"
+      * equivalence = #equal
+  * element[+]
+    * code = #entered-in-error
+    * display = "Entered in error"
+    * target
+      * equivalence = #unmatched
+      * comment = "There is no code for erroneously entered records in the Finnish logical model"
+  * element[+]
+    * code = #checked-in
+    * display = "Checked In"
+    * target
+      * code = #10
+      * display = "Ilmoittautunut"
+      * equivalence = #equivalent
+      * comment = "The Finnish logical model does not separate between arrived and checked-in codes"
+  * element[+]
+    * code = #waitlist
+    * display = "Waitlisted"
+    * target
+      * code = #1
+      * display = "Suunniteltu"
+      * equivalence = #narrower
+      * comment = "Use Suunniteltu when no service provider has been identified"
+    * target[+]
+      * code = #2
+      * display = "Tilattu"
+      * equivalence = #narrower
+      * comment = "Use Tilattu when a service provider has been identified"
+

--- a/input/fsh/mappings/appointment-status-concept-map.fsh
+++ b/input/fsh/mappings/appointment-status-concept-map.fsh
@@ -43,8 +43,6 @@ Usage: #definition
     * code = #5
     * display = "Siirretty"
     * target
-      * code = #cancelled
-      * display = "Cancelled"
       * equivalence = #unmatched
       * comment = "There is no status for rescheduled appointments in FHIR. This code SHOULD be mapped to cancelled, if required. Note that this code is deprecated."
   * element[+]

--- a/input/pagecontent/ConceptMap-appointment-status-concept-map-intro.md
+++ b/input/pagecontent/ConceptMap-appointment-status-concept-map-intro.md
@@ -1,0 +1,53 @@
+The Finnish logical model for appointments includes a code set for appointment statuses that
+differs from the FHIR
+[Appointment.status](https://hl7.org/fhir/R4B/appointment-definitions.html#Appointment.status)
+values.
+
+The Finnish logical model is more detailed when the service is being planned, and separates between
+states where the need fo a service has been identified but no service provider has yet been
+identified
+([#1, Suunniteltu](https://koodistopalvelu.kanta.fi/codeserver/pages/code-view-page.xhtml?conceptCodeKey=101027618)),
+and when the service provider has been selected
+([#2, Tilattu](https://koodistopalvelu.kanta.fi/codeserver/pages/code-view-page.xhtml?conceptCodeKey=101027619)).
+
+The FHIR specification uses the Appoinment resource to track information on scheduling and for
+administrative purposes, and the Encounter resource to track any clinically relevant information
+(see [Appointment Statuses and Encounters](https://hl7.org/fhir/R4B/appointment.html#statuses)). In
+FHIR, when an encounter starts, its state is tracked with the
+[Encounter](https://hl7.org/fhir/R4B/encounter.html) resource, and no longer with the
+[Appointment](https://hl7.org/fhir/R4B/appointment.html).
+
+The Finnish logical model does not make such a distinction. The same value set records states for
+when the encounter has started
+([#6, Alkanut](https://koodistopalvelu.kanta.fi/codeserver/pages/code-view-page.xhtml?conceptCodeKey=101027623))
+and when the service is in progress or completed
+([#7, Toteutunut](https://koodistopalvelu.kanta.fi/codeserver/pages/code-view-page.xhtml?conceptCodeKey=101027624)).
+
+The Finnish logical model does not have a separate state for when the patient has arrived (FHIR
+status `#arrived`). It does have a code #10 Ilmoittautunut that matches the FHIR code
+`#checked-in`.
+
+The Finnish logical model used to have a separate code for an appointment that has been rescheduled
+([#5, Siirretty](https://koodistopalvelu.kanta.fi/codeserver/pages/code-view-page.xhtml?conceptCodeKey=101027622)),
+but that code is now deprecated.
+
+The Finnish logical model does not have any code for appointments that have been entered in error.
+
+<style>
+  table.grid {
+    table-layout: fixed;
+    width: 100%;
+  }
+  table.grid td {
+    width: 20%;
+  }
+  table.grid td:nth-child(2) {
+    width: 10%;
+  }
+  table.grid td:nth-child(4) {
+    width: 50%;
+  }
+  table.grid tr:first-child td:last-child {
+    display: none;
+  }
+</style>


### PR DESCRIPTION
Map between the Finnish logical model and FHIR specification, both ways.

Add some styling too, to remove the last empty "properties" column from the tables, and to adjust column widths to improve legibility.

The `unmatched` codes do have comments in source code and in `fsh-generated` artifacts, but the IG publisher seems to strip these.