### PR TITLE
Fix PR check workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# This workflow will setup IG publisher, run sushi, and publish the results to GitHub Pages
+# This workflow sets up and runs the IG publisher and publishes the results to GitHub Pages
 
 name: Node.js CI
 
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Set permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
@@ -28,14 +28,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Update the Docker image to the latest publisher
-      uses: docker://hl7fhir/ig-publisher-base:latest
-      with:
-        args: curl -L https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar -o ./input-cache/publisher.jar --create-dirs
-    - name: Run the IG publisher
-      uses: docker://hl7fhir/ig-publisher-base:latest
-      with:
-        args: java -jar ./input-cache/publisher.jar publisher -ig .
+    - name: Setup IG publisher
+      run: docker compose run runner bash -c "./_updatePublisher.sh --yes"
+    - name: Generate the IG
+      run: docker compose run runner bash -c "./_genonce.sh"
     - name: Setup Pages
       uses: actions/configure-pages@v2
     - name: Upload artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ master ]
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/pr-verification.yml
+++ b/.github/workflows/pr-verification.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      name: Update the Docker image to the latest publisher
+    - name: Update the Docker image to the latest publisher
       uses: docker://hl7fhir/ig-publisher-base:latest
       with:
         args: curl -L https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar -o ./input-cache/publisher.jar --create-dirs

--- a/.github/workflows/pr-verification.yml
+++ b/.github/workflows/pr-verification.yml
@@ -2,7 +2,7 @@ name: Pull request verification
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pr-verification.yml
+++ b/.github/workflows/pr-verification.yml
@@ -11,5 +11,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Run sushi
-      run: docker compose run runner bash -c "sushi"
+      name: Update the Docker image to the latest publisher
+      uses: docker://hl7fhir/ig-publisher-base:latest
+      with:
+        args: curl -L https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar -o ./input-cache/publisher.jar --create-dirs
+    - name: Run the IG publisher
+      uses: docker://hl7fhir/ig-publisher-base:latest
+      with:
+        args: java -jar ./input-cache/publisher.jar publisher -ig .

--- a/.github/workflows/pr-verification.yml
+++ b/.github/workflows/pr-verification.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run sushi
-      run: docker-compose run runner bash -c "cd /workdir && sushi"
+      run: docker compose run runner bash -c "sushi"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:lts-bullseye
-RUN npm install -g fsh-sushi@3.3.3
+RUN npm install -g fsh-sushi
 
 RUN apt-get update && apt-get -y install openjdk-17-jdk-headless ruby-full build-essential zlib1g-dev
 RUN gem install jekyll bundler 


### PR DESCRIPTION
Both the PR check and the auto-deploy to fhir.fi broke when the primary branch name was changed from `main` to `master` a few months ago, to support the build.fhir.ig infrastructure.

The auto-build infra nowadays supports also other branch names as primary branches, but since we're using `master` in all other IG repos too, let's keep it here as well.

Also, let's take this opportunity to further improve the check. It now runs the entire publisher, not just sushi, to check that everything is in order.