### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Update the Docker image to the latest publisher
       uses: docker://hl7fhir/ig-publisher-base:latest
       with:
@@ -37,11 +37,11 @@ jobs:
       with:
         args: java -jar ./input-cache/publisher.jar publisher -ig .
     - name: Setup Pages
-      uses: actions/configure-pages@v2
+      uses: actions/configure-pages@v5
     - name: Upload artifacts
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3
       with:
         path: './output'
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v1
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/pr-verification.yml
+++ b/.github/workflows/pr-verification.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run sushi
       run: docker-compose run runner bash -c "cd /workdir && sushi"


### PR DESCRIPTION
Bring all actions to latest versions.

The IG won't build properly to GitHub pages due to this:

> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/