### PR TITLE
Kanta feedback

### DIFF
--- a/input/fsh/extensions/CareGuaranteeDetails.fsh
+++ b/input/fsh/extensions/CareGuaranteeDetails.fsh
@@ -3,5 +3,4 @@ Id: care-guarantee-details
 Title: "Care Guarantee Details"
 Description: "An extension for including care guarantee (*hoitotakuu*) details in appointment."
 Context: Appointment
-* value[x] 1..
 * value[x] only string

--- a/input/fsh/extensions/CareplanIdentifier.fsh
+++ b/input/fsh/extensions/CareplanIdentifier.fsh
@@ -4,4 +4,3 @@ Title: "Careplan Identifier"
 Description: "Identifier for the care plan, if provided."
 Context: Appointment
 * value[x] only Identifier
-* value[x].value 1..

--- a/input/fsh/extensions/ChildAppointment.fsh
+++ b/input/fsh/extensions/ChildAppointment.fsh
@@ -1,0 +1,6 @@
+Extension: ChildAppointment
+Id: child-appointment
+Title: "Child Appointment"
+Description: "Reference from a master (parent) appointment to its sub (child) appointments"
+Context: Appointment
+* value[x] only Identifier

--- a/input/fsh/extensions/ParentAppointment.fsh
+++ b/input/fsh/extensions/ParentAppointment.fsh
@@ -1,6 +1,0 @@
-Extension: ParentAppointment
-Id: parent-appointment
-Title: "Parent Appointment"
-Description: "Master appointment reference using identifier type (*Pääajanvarauksen tunniste*)"
-Context: Appointment
-* value[x] only Identifier

--- a/input/fsh/extensions/QueueNo.fsh
+++ b/input/fsh/extensions/QueueNo.fsh
@@ -3,5 +3,4 @@ Id: queue-number
 Title: "Queue Number"
 Description: "An extension for queue number (in string format)."
 Context: Appointment
-* value[x] 1..
 * value[x] only string

--- a/input/fsh/extensions/ReferralId.fsh
+++ b/input/fsh/extensions/ReferralId.fsh
@@ -3,5 +3,4 @@ Id: referral-id
 Title: "Referral Id"
 Description: "Referral id extension for appointment (string)"
 Context: Appointment
-* value[x] 1..
 * value[x] only string

--- a/input/fsh/profiles/FiSchedulingAppointment.fsh
+++ b/input/fsh/profiles/FiSchedulingAppointment.fsh
@@ -10,10 +10,10 @@ Description: "Base profile for appointment (*ajanvaraus*) in Finnish Scheduling 
     AppointmentMutability named AppointmentMutability 0..1 and
     CareGuaranteeDetails named CareGuaranteeDetails 0..1 and
     CareplanIdentifier named CareplanIdentifier 0..* and
+    ChildAppointment named ChildAppointment 0..1 and
     CustomerJourney named CustomerJourney 0..* and
     NotificationInfo named NotificationInfo 0..* and
     NotificationMedium named NotificationMedium 0..* and
-    ParentAppointment named ParentAppointment 0..1 and
     PractitionerGender named PractitionerGender 0..1 and
     QueueNo named QueueNo 0..* and
     ReferralId named ReferralId 0..* and


### PR DESCRIPTION
Some discussion from an email thread below. Hard to follow here, I know. Ask for more details if necessary.

Mikael
> Laajennosten elementtien pakollisuudet
>  
> Omasta mielestäni valuen ei tarvitsisi olla pakollinen. On kuitenkin ollut vanhastaan, niin ollaan oltu vähän arkoja poistamaan. Tuosta palautteestasi saadaan ehkä vähän lisää rohkeutta. Olisiko teille OK, että ei olisi erikseen merkattu pakolliseksi?
>  
> En myöskään itse ole löytänyt perustetta laajennoksen laajentamisen estämiselle. Minun puolestani voidaan ottaa rajoitteet pois. Onko OK, jos tehdään niin?

Mika
> On ok.
 
Mikael
> Laajennosten tietotyyppien rajoitteet
>  
> Juu, mieluummin niin, että laajemmassa kontekstissa vähemmän rajoitteita. Kyllä Identifierin osalta olen nähnyt ihan selkeitä käyttötapauksia myös elementeille use, type ja assigner. Ja vaikka periodiin en ole törmännytkään, en voisi sanoa, että ei ole tarvetta. Teillä tosiaan eri meininki, voitte selkeämmin kertoa mille on tarve ja mitä pystytte tai haluatte tallentaa. Tuonkin osalta toki sovelluskehittäjänä ennemmin näkisin sen mallin, että saan lähettää vaikka kuinka täydellistä tietoa ja palvelin saa sitten päättää mitä kaikkea siitä haluaa tallentaa tai kykenee tallentamaan.
 
Mika
> Pitää sitten profiloida meidän itse tiukemmaksi. Meillä on osin vastuu tietosisällön oikeellisuudesta ja me välitämme yhden tahon tietoja toisille tahoille. Tätä on yritetty aiemminkin, että vastuu tietosisällöstä on sen tuottajalla mutta kun niissä on virheitä (nyt siis näissä ”ylimääräisissä”, saamme siitä kuitenkin sapiskaa ja palautteen että emme validoi). Sinällään laajennokset käyttötarve varmaan pitäisi olla ennakkoon tiedossa ja näin myös käytettävät elementit. Laajennuksiin voisi/pitäisi speksata mitkä elementeistä ovat käytössä ja mitkä niistä ovat pakollisia.
 
Mikael
> Tietotyyppien pakollisuudet
>  
> Tässä ehkä sama kuin edellisessä. Yleisellä tasolla mieluummin vähemmän pakollisuuksia, mutta on sitten mahdollisuus pakottaa tarkemmin eri käyttötapauksissa.
> Jos on erityisesti perusteltuja muutostarpeita tähän, saa ehdottaa.
 
Mika
> Meidän mielestä systemit pitäisi olla pakollisia, ajanvaraus on jo aika tarkka käyttötapaus.
 
Mikael
> Koodatut tietotyypit
>  
> Tuossa on käytetty patternia varovaisuuden takia. Kun on ollut epäselvyyttä siitä, pitäisikö koodistopalvelimelta tulevissa oid-koodeissa merkitä versio tarvittaessa erikseen vai voiko systemissä käyttää merkkijonoa, jossa system ja version ovat samassa. Siis nyt sallitaan esim. laajennoksessa PractitionerGender sekä system urn:oid:1.2.246.537.5.1 että system 1.2.246.537.5.1.1997.
 
Mika:
> Tämä ei voi kyllä jäädä meillä näin avoimeksi. Koko versioasian ilmoittaminen kansallisesti pitäisi löydä lukkoon asap, ja harmi että tätä ei käsitelty jo suomalaisessa FHIR perusprofiloinnissa. Miten saamme pakotettua nyt versiollisen oidin systemiin? Pattern varmaan sallii myös tarkemman fixed valuen.
>  
> Onko pattern määreellä tapahtuva systemin rajaus myös vain merkkijono vertailu (että tuollainen vaadittu arvo on annettu)?. Se ei tosiaan riitä koodistovalidointeihin (löytyykö koodi tästä koodistosta), niitä varten pitäisi tehdä ValueSetit ja sitten ValueSetin bindaus koodattuun tietoon (nyt laajennokset koodattuun tietoon). Nyt tietosisältömäärittelyt vaativat tietyt koodistot, joten bindaus olisi tehtävissä jo laajennosten tasolla.
 
 
Mikael
> Käytetyt laajennokset
>  
> Kiitokset näistäkin!
>  
> Kerro SelfServiceInformationin osalta mihin päädytte, voidaan varmaankin sopeutua siihen.
 
Mika
> On ok, että URL on aina pakollinen

Mikael 
> ChildAppointmentin osalta meillä oli käsitys, että järjestelmät mieluummin tukisivat linkitystä toiseen suuntaan. Siis aina kun tiettyyn palvelutapahtumaan (tai muuten kattavampaan ajanvaraukseen) liittyy uusi aliajanvaraus, kerrotaan vain sen ajanvarauksen yhteydessä, että tämä liittyy tuohon laajempaan kokonaisuuteen. Että ei tarvitse sen vuoksi käydä päivittämässä sitä kattavampaa ajanvarausta. Onko teillä siis päädytty päinvastaiseen ratkaisuun? Oliko sille selkeät perustelut? Tästä oli kyllä puhetta silloin taannoin, mutta en saanut napattua muistiinpanoihin tuota perustetta. Voidaan kyllä tarvittaessa poimia se ChildAppointmentkin vielä mukaan.
 
Mika
> Aiemmin viittaukset oli ristiin sekä pääajanvaraukselta aliajanvaraukseen että aliajanvaraukselta pääajanvaraukseen. Nyt viittaus on vain pääajanvaraukselta aliajanvaraukseen, aliajanvaraukselta ei enää viitata pääajanvaraukseen. Aliajanvaraus kuitenkin siis tarvitaan. THL tämä tuli näin ja olemme noudattaneet niitä.
 
Mikael
> Lisäksi teillä taisi olla ainakin seuraavat omat laajennokset:
>  
> AppointmentType
> DetailedContent
> Jatkohoidon tai palveluprosessin lisätiedot
> ReleaseDateForPatientViewing
> RemoteServiceURL
> RequestedService
> ResourceCalendar
> RestrictionParent
> ServiceNeed
>  
> Löytyykö noista jokin tai joitakin, joille olisi parempi paikka yhdistyksen soveltamisoppaassa?
 
Mika
> Tähän meidän on vaikea vastata, sillä emme tiedä millainen tietomalli/tietosisältö varsinaisessa ajanvarausrajapinnassa on. > Aikataulusyistä johtuen emme enää mielellään avaisi näiden käsittelyä. Mikään ei tietenkään estä käyttämästä näitä meidän laajennuksia (meidän nimiavaruudessa) muuallakin.
 

