### PR TITLE
Fix IG urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ Build results may not be available.
 ### On hl7.fi
 
 The official publishing location of the implementation guide is at
-[hl7.fi/fhir/finnish-base-profiles/](https://hl7.fi/fhir/finnish-smart/).
+[hl7.fi/fhir/finnish-scheduling/](https://hl7.fi/fhir/finnish-scheduling).
 
 Occasionally snapshots are also published there. The published versions are listed on the
-[Version History](https://hl7.fi/fhir/finnish-smart/history.html) page.
+[Version History](https://hl7.fi/fhir/finnish-scheduling/history.html) page.
 
 # Contact
 


### PR DESCRIPTION
Copy-paste errors from previous guides